### PR TITLE
Add ability to import OpsWorks stacks

### DIFF
--- a/builtin/providers/aws/import_aws_opsworks_stack_test.go
+++ b/builtin/providers/aws/import_aws_opsworks_stack_test.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSOpsWorksStack_importBasic(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	name := acctest.RandString(10)
+
+	resourceName := "aws_opsworks_stack.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksStackDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsOpsworksStackConfigVpcCreate(name),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/import_aws_opsworks_stack_test.go
+++ b/builtin/providers/aws/import_aws_opsworks_stack_test.go
@@ -15,7 +15,7 @@ func TestAccAWSOpsWorksStack_importBasic(t *testing.T) {
 
 	name := acctest.RandString(10)
 
-	resourceName := "aws_opsworks_stack.bar"
+	resourceName := "aws_opsworks_stack.tf-acc"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -20,6 +20,9 @@ func resourceAwsOpsworksStack() *schema.Resource {
 		Read:   resourceAwsOpsworksStackRead,
 		Update: resourceAwsOpsworksStackUpdate,
 		Delete: resourceAwsOpsworksStackDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"agent_version": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -286,6 +286,9 @@ func resourceAwsOpsworksStackRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("default_subnet_id", stack.DefaultSubnetId)
 	d.Set("hostname_theme", stack.HostnameTheme)
 	d.Set("use_custom_cookbooks", stack.UseCustomCookbooks)
+	if stack.CustomJson != nil {
+		d.Set("custom_json", stack.CustomJson)
+	}
 	d.Set("use_opsworks_security_groups", stack.UseOpsworksSecurityGroups)
 	d.Set("vpc_id", stack.VpcId)
 	if color, ok := stack.Attributes["Color"]; ok {

--- a/builtin/providers/aws/resource_aws_opsworks_stack_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack_test.go
@@ -411,11 +411,11 @@ resource "aws_vpc" "tf-acc" {
 resource "aws_subnet" "tf-acc" {
   vpc_id = "${aws_vpc.tf-acc.id}"
   cidr_block = "${aws_vpc.tf-acc.cidr_block}"
-  availability_zone = "us-west-2a"
+  availability_zone = "us-east-1a"
 }
 resource "aws_opsworks_stack" "tf-acc" {
   name = "%s"
-  region = "us-west-2"
+  region = "us-east-1"
   vpc_id = "${aws_vpc.tf-acc.id}"
   default_subnet_id = "${aws_subnet.tf-acc.id}"
   service_role_arn = "${aws_iam_role.opsworks_service.arn}"

--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -67,6 +67,7 @@ To make a resource importable, please see the
 * aws_nat_gateway
 * aws_network_acl
 * aws_network_interface
+* aws_opsworks_stack
 * aws_placement_group
 * aws_rds_cluster
 * aws_rds_cluster_instance

--- a/website/source/docs/providers/aws/r/opsworks_stack.html.markdown
+++ b/website/source/docs/providers/aws/r/opsworks_stack.html.markdown
@@ -76,3 +76,12 @@ The `custom_cookbooks_source` block supports the following arguments:
 The following attributes are exported:
 
 * `id` - The id of the stack.
+
+
+## Import
+
+OpsWorks stacks can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_opsworks_stack.bar 00000000-0000-0000-0000-000000000000
+```


### PR DESCRIPTION
Acceptance test passes:
`vagrant@terraform:/opt/gopath/src/github.com/hashicorp/terraform$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsWorksStack_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/09/29 11:55:52 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsWorksStack_importBasic -timeout 120m
=== RUN   TestAccAWSOpsWorksStack_importBasic
--- PASS: TestAccAWSOpsWorksStack_importBasic (56.48s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    56.496s`
